### PR TITLE
update all URLs to point to educationdata.urban.org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Date: 2022-07-13
 URL: https://urbaninstitute.github.io/education-data-package-r/
 BugReports: https://github.com/UrbanInstitute/education-data-package-r/issues
 Description: Allows R users to retrieve and parse data from the Urban 
-    Institute's Education Data API <https://edudcationdata.urban.org/> into a 
+    Institute's Education Data API <https://educationdata.urban.org/> into a 
     'data.frame' for analysis.
 Depends: R (>= 3.4.0)
 Imports:

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/UrbanInstitute/education-data-package-r/workflows/R-CMD-check/badge.svg)](https://github.com/UrbanInstitute/education-data-package-r/actions)
 <!-- badges: end -->
 
-Retrieve data from the Urban Institute's [Education Data API](https://ed-data-portal.urban.org/) as a `data.frame` for easy analysis.
+Retrieve data from the Urban Institute's [Education Data API](https://educationdata.urban.org/) as a `data.frame` for easy analysis.
 
 **NOTE**: By downloading and using this programming package, you agree to abide
 by the [Data Policy and Terms of Use of the Education Data Portal](https://educationdata.urban.org/documentation/#terms).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ status](https://www.r-pkg.org/badges/version/educationdata)](https://cran.r-proj
 <!-- badges: end -->
 
 Retrieve data from the Urban Institute’s [Education Data
-API](https://ed-data-portal.urban.org/) as a `data.frame` for easy
+API](https://educationdata.urban.org/) as a `data.frame` for easy
 analysis.
 
 **NOTE**: By downloading and using this programming package, you agree
@@ -58,7 +58,7 @@ str(df)
 #>  $ race       : Factor w/ 14 levels "White","Black",..: 2 3 5 5 2 4 6 11 1 7 ...
 #>  $ sex        : Factor w/ 7 levels "Male","Female",..: 1 1 2 1 2 2 2 1 2 1 ...
 #>  $ enrollment : int  41 39 0 0 46 32 3 270 166 0 ...
-#>  $ fips       : Factor w/ 80 levels "Alabama","Alaska",..: 34 34 34 34 34 34 34 34 34 34 ...
+#>  $ fips       : Factor w/ 79 levels "Alabama","Alaska",..: 34 34 34 34 34 34 34 34 34 34 ...
 #>  $ leaid      : chr  "3406060" "3406060" "3406060" "3406060" ...
 ```
 
@@ -263,6 +263,7 @@ Let’s build up some examples, from the following set of endpoints.
 | schools | crdc   | enrollment | disability, sex | year         | 2011, 2013, 2015, 2017 |
 | schools | crdc   | enrollment | lep, sex        | year         | 2011, 2013, 2015, 2017 |
 | schools | crdc   | enrollment | race, sex       | year         | 2011, 2013, 2015, 2017 |
+| NA      | NA     | NA         | NULL            | NULL         | NA                     |
 
 The following will return a `data.frame` across all years and grades:
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ Let’s build up some examples, from the following set of endpoints.
 | schools | crdc   | enrollment | disability, sex | year         | 2011, 2013, 2015, 2017 |
 | schools | crdc   | enrollment | lep, sex        | year         | 2011, 2013, 2015, 2017 |
 | schools | crdc   | enrollment | race, sex       | year         | 2011, 2013, 2015, 2017 |
-| NA      | NA     | NA         | NULL            | NULL         | NA                     |
 
 The following will return a `data.frame` across all years and grades:
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,6 +4,7 @@ This is a resubmission. In this version I have:
 * Removed grade level arguments that are no longer included in the [Education Data API](https://educationdata.urban.org/documentation/) 
 * Updated topic validation to accommodate a new endpoint added to the [Education Data API](https://educationdata.urban.org/documentation/)
 * Updated the README to reflect the current endpoints and years available in the [Education Data API](https://educationdata.urban.org/documentation/) 
+* Updated all URLs to use https://educationdata.urban.org/ 
 
 ## Test environments
 * local ubuntu 20.04 install, R 4.1.0

--- a/docs/articles/introducing-educationdata.html
+++ b/docs/articles/introducing-educationdata.html
@@ -92,7 +92,7 @@ Ueyama</h4>
     
     
 <p>The <code>educationdata</code> package allows the user to retrieve
-data from the Urban Institute’s <a href="https://ed-data-portal.urban.org/" class="external-link">Education Data API</a> as a
+data from the Urban Institute’s <a href="https://educationdata.urban.org/" class="external-link">Education Data API</a> as a
 <code>data.frame</code> for analysis. The package contains one major
 function, <code>get_education_data</code>, which will get data from a
 specified API endpoint and return a <code>data.frame</code> to the

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
 <!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script><!-- headroom.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
 <script src="pkgdown.js"></script><meta property="og:title" content="Retrieve Records from the Urban Institute's Education Data Portal API  ">
 <meta property="og:description" content="Allows R users to retrieve and parse data from the Urban 
-    Institutes Education Data API &lt;https://edudcationdata.urban.org/&gt; into a 
+    Institutes Education Data API &lt;https://educationdata.urban.org/&gt; into a 
     data.frame' for analysis.">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -84,7 +84,7 @@
 </h1></div>
 <!-- badges: start -->
 
-<p>Retrieve data from the Urban Institute’s <a href="https://ed-data-portal.urban.org/" class="external-link">Education Data API</a> as a
+<p>Retrieve data from the Urban Institute’s <a href="https://educationdata.urban.org/" class="external-link">Education Data API</a> as a
 <code>data.frame</code> for easy analysis.</p>
 <p><strong>NOTE</strong>: By downloading and using this programming
 package, you agree to abide by the <a href="https://educationdata.urban.org/documentation/#terms" class="external-link">Data Policy
@@ -126,7 +126,7 @@ with:</p>
 <span class="co">#&gt;  $ race       : Factor w/ 14 levels "White","Black",..: 2 3 5 5 2 4 6 11 1 7 ...</span>
 <span class="co">#&gt;  $ sex        : Factor w/ 7 levels "Male","Female",..: 1 1 2 1 2 2 2 1 2 1 ...</span>
 <span class="co">#&gt;  $ enrollment : int  41 39 0 0 46 32 3 270 166 0 ...</span>
-<span class="co">#&gt;  $ fips       : Factor w/ 80 levels "Alabama","Alaska",..: 34 34 34 34 34 34 34 34 34 34 ...</span>
+<span class="co">#&gt;  $ fips       : Factor w/ 79 levels "Alabama","Alaska",..: 34 34 34 34 34 34 34 34 34 34 ...</span>
 <span class="co">#&gt;  $ leaid      : chr  "3406060" "3406060" "3406060" "3406060" ...</span></code></pre></div>
 <p>The <code><a href="reference/get_education_data.html">get_education_data()</a></code> function will return a
 <code>data.frame</code> from a call to the Education Data API.</p>
@@ -1349,6 +1349,14 @@ endpoints.</p>
 <td align="left">race, sex</td>
 <td align="left">year</td>
 <td align="left">2011, 2013, 2015, 2017</td>
+</tr>
+<tr class="even">
+<td align="left">NA</td>
+<td align="left">NA</td>
+<td align="left">NA</td>
+<td align="left">NULL</td>
+<td align="left">NULL</td>
+<td align="left">NA</td>
 </tr>
 </tbody>
 </table>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   introducing-educationdata: introducing-educationdata.html
-last_built: 2022-07-19T16:00Z
+last_built: 2022-07-19T17:18Z
 

--- a/vignettes/introducing-educationdata.Rmd
+++ b/vignettes/introducing-educationdata.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 The `educationdata` package allows the user to retrieve data from the Urban 
-Institute's [Education Data API](https://ed-data-portal.urban.org/) as a 
+Institute's [Education Data API](https://educationdata.urban.org/) as a 
 `data.frame` for analysis. The package contains one major function, 
 `get_education_data`, which will get data from a specified API endpoint and 
 return a `data.frame` to the user.


### PR DESCRIPTION
* Fixed a misspelling from `edudcationdata.urban.org` to `educationdata.urban.org` 
* Updated all instances of `ed-data-portal.urban.org` to `educationdata.urban.org` 