### PR TITLE
update CRAN links to use canonical URL

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ by the [Data Policy and Terms of Use of the Education Data Portal](https://educa
 
 ## Installation
 
-You can install the released version of `educationdata` from [CRAN](https://cran.r-project.org/web/packages/educationdata/index.html) with: 
+You can install the released version of `educationdata` from [CRAN](https://CRAN.R-project.org/package=educationdata) with: 
 
 ```{r cran-installation, eval=FALSE}
 install.packages("educationdata")

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Portal](https://educationdata.urban.org/documentation/#terms).
 ## Installation
 
 You can install the released version of `educationdata` from
-[CRAN](https://cran.r-project.org/web/packages/educationdata/index.html)
-with:
+[CRAN](https://CRAN.R-project.org/package=educationdata) with:
 
 ``` r
 install.packages("educationdata")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,6 +5,7 @@ This is a resubmission. In this version I have:
 * Updated topic validation to accommodate a new endpoint added to the [Education Data API](https://educationdata.urban.org/documentation/)
 * Updated the README to reflect the current endpoints and years available in the [Education Data API](https://educationdata.urban.org/documentation/) 
 * Updated all URLs to use https://educationdata.urban.org/ 
+* Updated CRAN URLs to use https://CRAN.R-project.org/package=educationdata
 
 ## Test environments
 * local ubuntu 20.04 install, R 4.1.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,7 +93,7 @@ and Terms of Use of the Education Data Portal</a>.</p>
 <h2 id="installation">Installation<a class="anchor" aria-label="anchor" href="#installation"></a>
 </h2>
 <p>You can install the released version of <code>educationdata</code>
-from <a href="https://cran.r-project.org/web/packages/educationdata/index.html" class="external-link">CRAN</a>
+from <a href="https://CRAN.R-project.org/package=educationdata" class="external-link">CRAN</a>
 with:</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html" class="external-link">install.packages</a></span><span class="op">(</span><span class="st">"educationdata"</span><span class="op">)</span></code></pre></div>
@@ -1349,14 +1349,6 @@ endpoints.</p>
 <td align="left">race, sex</td>
 <td align="left">year</td>
 <td align="left">2011, 2013, 2015, 2017</td>
-</tr>
-<tr class="even">
-<td align="left">NA</td>
-<td align="left">NA</td>
-<td align="left">NA</td>
-<td align="left">NULL</td>
-<td align="left">NULL</td>
-<td align="left">NA</td>
 </tr>
 </tbody>
 </table>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   introducing-educationdata: introducing-educationdata.html
-last_built: 2022-07-19T17:18Z
+last_built: 2022-07-19T21:23Z
 


### PR DESCRIPTION
Use the canonical URL of the CRAN page for a package: https://CRAN.R-project.org/package=educationdata. 