### PR TITLE
update tests to skip on CRAN 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *benchmarks/*
 *doc
 *Meta
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: educationdata
 Type: Package
 Title: Retrieve Records from the Urban Institute's Education Data Portal API  
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
     person("Erika", "Tyagi", email = "etyagi@urban.org", role = "cre"), 
     person("Kyle", "Ueyama", email = "khueyama@gmail.com", role = "aut"),
     person(given = "The Urban Institute", role = c("cph"))
     )
-Date: 2022-07-13
+Date: 2022-09-29
 URL: https://urbaninstitute.github.io/education-data-package-r/
 BugReports: https://github.com/UrbanInstitute/education-data-package-r/issues
 Description: Allows R users to retrieve and parse data from the Urban 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## educationdata 0.1.3 (2022-09-29)
 * Updated test suite to to comply with the following CRAN policy: 
     > Packages which use Internet resources should fail gracefully with an informative message if the resource is not available or has changed (and not give a check warning nor error).
+    
 ## educationdata 0.1.2 (2022-07-13)
 
 * Removed old grade levels from CCD endpoints.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## educationdata 0.1.3 (2022-09-29)
+* Updated test suite to to comply with the following CRAN policy: 
+    > Packages which use Internet resources should fail gracefully with an informative message if the resource is not available or has changed (and not give a check warning nor error).
 ## educationdata 0.1.2 (2022-07-13)
 
 * Removed old grade levels from CCD endpoints.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,6 +6,7 @@ This is a resubmission. In this version I have updated the test suite to comply 
 * macOS-latest (release) (via GitHub actions R-CMD-check)
 * windows-latest (release) (via GitHub actions R-CMD-check)
 * ubuntu-latest (devel, release, oldrel-1) (via GitHub actions R-CMD-check)
+* win-builder (devel and release) 
 * Windows Server 2022, R-devel, 64 bit (via R-hub)
 * Fedora Linux, R-devel, clang, gfortran (via R-hub)
 * Ubuntu Linux 20.04.1 LTS, R-release, GCC (via R-hub)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,19 +1,17 @@
 ## Resubmission
-This is a resubmission. In this version I have:
-* Updated the creator in the DESCRIPTION 
-* Removed grade level arguments that are no longer included in the [Education Data API](https://educationdata.urban.org/documentation/) 
-* Updated topic validation to accommodate a new endpoint added to the [Education Data API](https://educationdata.urban.org/documentation/)
-* Updated the README to reflect the current endpoints and years available in the [Education Data API](https://educationdata.urban.org/documentation/) 
-* Updated all URLs to use https://educationdata.urban.org/ 
-* Updated CRAN URLs to use https://CRAN.R-project.org/package=educationdata
+This is a resubmission. In this version I have updated the test suite to comply with the following policy (per an email from CRAN on 2022-09-26): 
+> Packages which use Internet resources should fail gracefully with an informative message if the resource is not available or has changed (and not give a check warning nor error).
 
 ## Test environments
-* local ubuntu 20.04 install, R 4.1.0
-* ubuntu 18.04 (on travis-ci), R 4.0.4
-* win-builder (devel and release)
+* macOS-latest (release) (via GitHub actions R-CMD-check)
+* windows-latest (release) (via GitHub actions R-CMD-check)
+* ubuntu-latest (devel, release, oldrel-1) (via GitHub actions R-CMD-check)
+* Windows Server 2022, R-devel, 64 bit (via R-hub)
+* Fedora Linux, R-devel, clang, gfortran (via R-hub)
+* Ubuntu Linux 20.04.1 LTS, R-release, GCC (via R-hub)
 
 ## R CMD check results
-There were no ERRORs, WARNINGs, or NOTEs.
+0 errors | 0 warnings | 0 notes
 
 ## Downstream dependencies
 There are currently no downstream dependencies for this package.

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/articles/introducing-educationdata.html
+++ b/docs/articles/introducing-educationdata.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 
@@ -81,13 +81,13 @@
 
     <p>Ueyama K (2022).
 <em>educationdata: Retrieve Records from the Urban Institute's Education Data Portal API</em>.
-R package version 0.1.2, <a href="https://urbaninstitute.github.io/education-data-package-r/" class="external-link">https://urbaninstitute.github.io/education-data-package-r/</a>. 
+R package version 0.1.3, <a href="https://urbaninstitute.github.io/education-data-package-r/" class="external-link">https://urbaninstitute.github.io/education-data-package-r/</a>. 
 </p>
     <pre>@Manual{,
   title = {educationdata: Retrieve Records from the Urban Institute's Education Data Portal API},
   author = {Kyle Ueyama},
   year = {2022},
-  note = {R package version 0.1.2},
+  note = {R package version 0.1.3},
   url = {https://urbaninstitute.github.io/education-data-package-r/},
 }</pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 
@@ -58,7 +58,16 @@
     </div>
 
     <div class="section level2">
-<h2 class="page-header" data-toc-text="0.1.2" id="educationdata-012-2022-07-13">educationdata 0.1.2 (2022-07-13)<a class="anchor" aria-label="anchor" href="#educationdata-012-2022-07-13"></a></h2>
+<h2 class="page-header" data-toc-text="0.1.3" id="educationdata-013-2022-09-29">educationdata 0.1.3 (2022-09-29)<a class="anchor" aria-label="anchor" href="#educationdata-013-2022-09-29"></a></h2>
+<ul><li>Updated test suite to to comply with the following CRAN policy:</li>
+</ul><blockquote>
+<p>Packages which use Internet resources should fail gracefully with an
+informative message if the resource is not available or has changed (and
+not give a check warning nor error).</p>
+</blockquote>
+</div>
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="0.1.2" id="educationdata-012-2022-07-13">educationdata 0.1.2 (2022-07-13)<small>2022-07-20</small><a class="anchor" aria-label="anchor" href="#educationdata-012-2022-07-13"></a></h2>
 <ul><li>Removed old grade levels from CCD endpoints.</li>
 <li>Fixed issue with <code>topic</code> validation to accommodate MEPS
 endpoint.</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   introducing-educationdata: introducing-educationdata.html
-last_built: 2022-07-19T21:23Z
+last_built: 2022-09-29T11:12Z
 

--- a/docs/reference/get_education_data.html
+++ b/docs/reference/get_education_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/reference/get_education_data_summary.html
+++ b/docs/reference/get_education_data_summary.html
@@ -20,7 +20,7 @@ endpoint functionality."><!-- mathjax --><script src="https://cdnjs.cloudflare.c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">educationdata</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.1.3</span>
       </span>
     </div>
 

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1,6 +1,7 @@
 context("api")
 
 test_that("api returns consistent results", {
+  skip_on_cran()
 
   ids <- c(234669 , 236610 , 236692)
 

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -1,6 +1,7 @@
 context('csv')
 
 test_that('csv returns same results as api', {
+  skip_on_cran()
   df1 <- get_education_data(level = 'college-university',
                             source = 'ipeds',
                             topic = 'student-faculty-ratio',
@@ -27,6 +28,7 @@ test_that('csv returns same results as api', {
 })
 
 test_that("ipeds filters properly parsed when pulling from csv", {
+  skip_on_cran()
   df1 <- get_education_data(level = "college-university",
                             source = "ipeds",
                             topic = "fall-enrollment",
@@ -54,6 +56,7 @@ test_that("ipeds filters properly parsed when pulling from csv", {
 })
 
 test_that("ccd filters properly parsed when pulling from csv", {
+  skip_on_cran()
   df1 <- get_education_data(
     level = 'schools',
     source = 'ccd',
@@ -79,6 +82,7 @@ test_that("ccd filters properly parsed when pulling from csv", {
 })
 
 test_that("edfacts filters properly parsed when pulling from csv", {
+  skip_on_cran()
   df1 <- get_education_data(
     level = 'schools',
     source = 'edfacts',

--- a/tests/testthat/test-summary-endpoints.R
+++ b/tests/testthat/test-summary-endpoints.R
@@ -1,6 +1,7 @@
 context("summary endpoints")
 
 test_that("basic summary endpoints function call returns results", {
+  skip_on_cran()
 
   df <- get_education_data_summary(
     level = "schools",
@@ -18,6 +19,7 @@ test_that("basic summary endpoints function call returns results", {
 })
 
 test_that("summary endpoints function call handles subtopics", {
+  skip_on_cran()
 
   df <- get_education_data_summary(
     level = "schools",
@@ -36,6 +38,7 @@ test_that("summary endpoints function call handles subtopics", {
 })
 
 test_that("summary endpoints function handles multiple group_by vars", {
+  skip_on_cran()
 
   by <- c("fips", "race")
 
@@ -56,6 +59,7 @@ test_that("summary endpoints function handles multiple group_by vars", {
 })
 
 test_that("summary endpoints function handles filters correctly", {
+  skip_on_cran()
 
   filters = list(
     fips = 6,
@@ -81,6 +85,7 @@ test_that("summary endpoints function handles filters correctly", {
 })
 
 test_that("summary endpoints function returns expected errors", {
+  skip_on_cran()
 
 
   expect_error(

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1,6 +1,7 @@
 context('validation')
 
 test_that('invalid api arguments return an error message', {
+  skip_on_cran()
   expect_error(get_education_data(level = 'fake',
                                   source = 'ccd',
                                   topic = 'enrollment'))


### PR DESCRIPTION
Adds `testthat::skip_on_cran()` in response to the following email from CRAN: 
> It seems we need to remind you of the CRAN policy:
>
> 'Packages which use Internet resources should fail gracefully with an informative message if the resource is not available or has changed (and not give a check warning nor error).'
> 
> This needs correction whether or not the resource recovers.

And the following guidance from rOpenSci ([here](https://books.ropensci.org/http-testing/graceful.html)):
> Your tests should ideally run without needing an actual internet connection nor the API being up. Your tests that do need to interact with the API should be skipped on CRAN. [testthat::skip_on_cran()](https://testthat.r-lib.org/reference/skip.html) will ensure that.

Bumps up the version number and rebuilds the package for CRAN resubmission accordingly. Also adds additional test environments. 